### PR TITLE
Add support for EvoVLM models in Heron VLM Leaderboard

### DIFF
--- a/heron/eval/configs/SakanaAI-EvoVLM-JP-v1-7B.yaml
+++ b/heron/eval/configs/SakanaAI-EvoVLM-JP-v1-7B.yaml
@@ -1,0 +1,44 @@
+wandb:
+  log: True
+  entity: "vision-language-leaderboard"
+  project: "heron-leaderboard"
+  run_name: 'SakanaAI/EvoVLM-JP-v1-7B'
+  launch: false
+
+# basic information
+testmode: false
+torch_dtype: "fp16" # {fp16, bf16, fp32}
+# if you don't use api, please set "api" as "false"
+# if you use api, please select from "openai", "anthoropic", "google", "cohere", "mistral", "amazon_bedrock"
+api: false
+model_artifact: null
+processor_artifact: null
+tokenizer_artifact: null
+
+model:
+  _target_: transformers.AutoModelForVision2Seq.from_pretrained
+  pretrained_model_name_or_path: 'SakanaAI/EvoVLM-JP-v1-7B'
+  torch_dtype: "float16"
+  ignore_mismatched_sizes: true
+
+processor:
+  _target_: transformers.AutoImageProcessor.from_pretrained
+  pretrained_model_name_or_path: null
+  
+tokenizer:
+  _target_: transformers.AutoTokenizer.from_pretrained
+  pretrained_model_name_or_path: null
+
+datasets:
+  llava_bench_in_the_wild_artifact_path: 'vision-language-leaderboard/heron-leaderboard/llava-bench-in-the-wild:v0'
+  llava_bench_in_the_wild_reference_path: 'vision-language-leaderboard/heron-leaderboard/llava-bench-in-the-wild-reference:v0'
+  japanese_heron_bench_artifact_path: 'vision-language-leaderboard/heron-leaderboard/japanese-heron-bench:v0'
+  japanese_heron_bench_reference_path: 'vision-language-leaderboard/heron-leaderboard/heron-bench-reference:v0'
+
+generation:
+  args:
+    max_length: 256
+    do_sample: false
+    temperature: 0.0
+    top_p: 0.0
+    no_repeat_ngram_size: 2


### PR DESCRIPTION
## Add support for EvoVLM models in Heron evaluation framework

### PR Description:
This pull request introduces support for evaluating EvoVLM models within the Heron VLM Leaderboard. The changes include:

- Added a new configuration file `SakanaAI-EvoVLM-JP-v1-7B.yaml` to define the settings for the EvoVLM-JP-v1-7B model.
- Modified the `vandl_adapter.py` script to include the necessary classes and functions for handling EvoVLM models:
  - Added the `EvoVLM` list to keep track of supported EvoVLM model names.
  - Implemented the `EvoVLMResponseGenerator` class to generate responses using EvoVLM models.
  - Updated the `get_adapter()` function to create an instance of `EvoVLMResponseGenerator` when an EvoVLM model is specified in the configuration.

The changes have been tested, and the evaluation results for the EvoVLM-JP-v1-7B model can be viewed at the following URL:
https://wandb.ai/vision-language-leaderboard/heron-leaderboard/runs/tt2eahu4

This addition expands the capabilities of the Heron evaluation framework, allowing users to easily evaluate and compare the performance of EvoVLM models alongside other supported models.